### PR TITLE
Update terminology for consistency with other components

### DIFF
--- a/src/connectid.js
+++ b/src/connectid.js
@@ -28,7 +28,7 @@ const isLocallyOptedOut = () => {
  */
 const getIds = ({pixelId, email, puid, yahoo1p}, callback) => {
   if (isLocallyOptedOut()) {
-    state.clear();
+    state.clearLocalData();
     callback({});
     return;
   }

--- a/src/connectid.js
+++ b/src/connectid.js
@@ -35,8 +35,8 @@ const getIds = ({pixelId, email, puid, yahoo1p}, callback) => {
 
   sha256.getHashedIdentifier(email, hashedEmail => {
     sha256.getHashedIdentifier(puid, hashedPuid => {
-      sync.syncIds({pixelId, hashedEmail, hashedPuid, yahoo1p});
-      callback(state.getConnectId({hashedEmail, hashedPuid}));
+      sync.syncIds({pixelId, he: hashedEmail, puid: hashedPuid, yahoo1p});
+      callback(state.getConnectId({he: hashedEmail, puid: hashedPuid}));
     });
   });
 };

--- a/src/state.js
+++ b/src/state.js
@@ -43,7 +43,7 @@ const getConnectId = ({hashedEmail, hashedPuid} = {}) => {
   return {};
 };
 
-const setConnectId = (data = {}) => {
+const setLocalData = (data = {}) => {
   const expires = computeExpiration(data.ttl).getTime();
   const updatedData = {
     ...pick(getLocalData(), ['hashedEmail', 'hashedPuid']),
@@ -57,7 +57,7 @@ const setConnectId = (data = {}) => {
   }
 };
 
-const clear = () => {
+const clearLocalData = () => {
   try {
     localStorage.removeItem(LOCALSTORAGE_KEY);
   } catch (e) {
@@ -67,7 +67,7 @@ const clear = () => {
 
 export default {
   getLocalData,
+  setLocalData,
+  clearLocalData,
   getConnectId,
-  setConnectId,
-  clear,
 };

--- a/src/state.js
+++ b/src/state.js
@@ -28,17 +28,17 @@ const getLocalData = () => {
   }
 };
 
-const getConnectId = ({hashedEmail, hashedPuid} = {}) => {
+const getConnectId = ({he, puid} = {}) => {
   const localData = getLocalData();
-  // if no ids provided or any id matches, return connectid
+  // if no ids provided or any id matches, return connectId
   if (
-    (!hashedEmail && !hashedPuid)
-    || (!hashedEmail && !!localData.hashedEmail)
-    || (hashedEmail && hashedEmail === localData.hashedEmail)
-    || (!hashedPuid && !!localData.hashedPuid)
-    || (hashedPuid && hashedPuid === localData.hashedPuid)
+    (!he && !puid)
+    || (!he && !!localData.he)
+    || (he && he === localData.he)
+    || (!puid && !!localData.puid)
+    || (puid && puid === localData.puid)
   ) {
-    return pick(localData, ['connectid']);
+    return pick(localData, ['connectId']);
   }
   return {};
 };
@@ -46,8 +46,8 @@ const getConnectId = ({hashedEmail, hashedPuid} = {}) => {
 const setLocalData = (data = {}) => {
   const expires = computeExpiration(data.ttl).getTime();
   const updatedData = {
-    ...pick(getLocalData(), ['hashedEmail', 'hashedPuid']),
-    ...pick(data, ['hashedEmail', 'hashedPuid', 'connectid']),
+    ...pick(getLocalData(), ['he', 'puid']),
+    ...pick(data, ['he', 'puid', 'connectId']),
     expires,
   };
   try {

--- a/src/sync.js
+++ b/src/sync.js
@@ -73,7 +73,7 @@ sync.syncIds = ({
 
     api.sendRequest(url, data, response => {
       if (response) {
-        state.setConnectId({
+        state.setLocalData({
           ...latestHashedEmail ? {hashedEmail: latestHashedEmail} : {},
           ...latestHashedPuid ? {hashedPuid: latestHashedPuid} : {},
           connectid: response.connectid,

--- a/src/test/api.spec.js
+++ b/src/test/api.spec.js
@@ -27,7 +27,7 @@ describe('api', () => {
       expect(requests[0].url).toBe('mock_url?he=abc');
     });
 
-    it('should call UPS to fetch ConnectID when no hashed email is provided', () => {
+    it('should call UPS to fetch ConnectID when no he is provided', () => {
       api.sendRequest('mock_url', {}, sinon.fake());
 
       expect(requests.length).toBe(1);
@@ -36,14 +36,14 @@ describe('api', () => {
 
     it('should pass API response to callback', done => {
       api.sendRequest('mock url', {he: 'abc'}, response => {
-        expect(response.connectid).toBe('fake_ connectid');
+        expect(response.connectId).toBe('fake_connectId');
         done();
       });
 
       requests[0].respond(
         200,
         {'Content-Type': 'application/json'},
-        '{"connectid": "fake_ connectid"}',
+        '{"connectId": "fake_connectId"}',
       );
     });
 

--- a/src/test/connectid.spec.js
+++ b/src/test/connectid.spec.js
@@ -1,6 +1,6 @@
 /* Copyright Yahoo, Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms. */
 
-import connectid from '../connectid';
+import connectId from '../connectid';
 import sync from '../sync';
 import api from '../api';
 import sha256 from '../sha256';
@@ -16,7 +16,7 @@ const mockGetHashedIdentifier = (id, callback) => {
 const noop = () => {
 };
 
-describe('connectid', () => {
+describe('connectId', () => {
   describe('getIds', () => {
     beforeEach(() => {
       localStorage.clear();
@@ -31,60 +31,60 @@ describe('connectid', () => {
     it('should clear local cache if connectIdOptOut is set', () => {
       mockPrivacySignals(true);
       const state = {
-        hashedEmail: 'abc',
-        connectid: 'abc_connectid',
+        he: 'abc',
+        connectId: 'abc_connectId',
         expires: 1596026151361,
       };
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(state));
       window.localStorage.setItem('connectIdOptOut', '1');
-      connectid.getIds({pixelId: 123, email: 'abc'}, noop);
-      expect(window.localStorage.getItem('yahoo-connectid')).toBe(null);
+      connectId.getIds({pixelId: 123, email: 'abc'}, noop);
+      expect(window.localStorage.getItem(LOCALSTORAGE_KEY)).toBe(null);
     });
 
     it('should clear local cache if _pbjs_id_optout is set', () => {
       mockPrivacySignals(true);
       const state = {
-        hashedEmail: 'abc',
-        connectid: 'abc_connectid',
+        he: 'abc',
+        connectId: 'abc_connectId',
         expires: 1596026151361,
       };
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(state));
       window.localStorage.setItem('_pbjs_id_optout', '1');
-      connectid.getIds({pixelId: 123, email: 'abc'}, noop);
-      expect(window.localStorage.getItem('yahoo-connectid')).toBe(null);
+      connectId.getIds({pixelId: 123, email: 'abc'}, noop);
+      expect(window.localStorage.getItem(LOCALSTORAGE_KEY)).toBe(null);
     });
 
     it('should clear local cache if _pubcid_optout is set', () => {
       mockPrivacySignals(true);
       const state = {
-        hashedEmail: 'abc',
-        connectid: 'abc_connectid',
+        he: 'abc',
+        connectId: 'abc_connectId',
         expires: 1596026151361,
       };
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(state));
       window.localStorage.setItem('_pubcid_optout', '1');
-      connectid.getIds({pixelId: 123, email: 'abc'}, noop);
-      expect(window.localStorage.getItem('yahoo-connectid')).toBe(null);
+      connectId.getIds({pixelId: 123, email: 'abc'}, noop);
+      expect(window.localStorage.getItem(LOCALSTORAGE_KEY)).toBe(null);
     });
 
     it('should not clear local cache if connectIdOptOut is not 1', () => {
       mockPrivacySignals(false, '1---', false);
       const state = {
-        hashedEmail: 'abc',
-        connectid: 'abc_connectid',
+        he: 'abc',
+        connectId: 'abc_connectId',
         expires: 1596026151361,
       };
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(state));
       window.localStorage.setItem('connectIdOptOut', '2');
-      connectid.getIds({pixelId: 123, email: 'abc'}, noop);
-      expect(window.localStorage.getItem('yahoo-connectid')).not.toBe(null);
+      connectId.getIds({pixelId: 123, email: 'abc'}, noop);
+      expect(window.localStorage.getItem(LOCALSTORAGE_KEY)).not.toBe(null);
     });
 
     it('should not initate sync if connectOptOut is 1', done => {
       mockPrivacySignals(true);
       window.localStorage.setItem('connectIdOptOut', '1');
       spyOn(sync, 'syncIds');
-      connectid.getIds({pixelId: 123, email: 'abc'}, () => {
+      connectId.getIds({pixelId: 123, email: 'abc'}, () => {
         expect(sync.syncIds).not.toHaveBeenCalled();
         done();
       });
@@ -93,7 +93,7 @@ describe('connectid', () => {
     it('should sync if connectIdOptOut is not 1', done => {
       mockPrivacySignals(false, '1---', false);
       spyOn(sync, 'syncIds');
-      connectid.getIds({pixelId: 123, email: 'abc'}, () => {
+      connectId.getIds({pixelId: 123, email: 'abc'}, () => {
         expect(sync.syncIds).toHaveBeenCalled();
         done();
       });
@@ -105,15 +105,15 @@ describe('connectid', () => {
       mockPrivacySignals(false, '1---', false);
       const he = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
       const state = {
-        hashedEmail: he,
-        connectid: 'abc_connectid',
+        he,
+        connectId: 'abc_connectId',
         expires: 1596026151361,
       };
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(state));
 
-      connectid.getIds({pixelId: 12345, email: he}, response => {
+      connectId.getIds({pixelId: 12345, email: he}, response => {
         expect(response).toEqual({
-          connectid: 'abc_connectid',
+          connectId: 'abc_connectId',
         });
         done();
       });
@@ -121,7 +121,7 @@ describe('connectid', () => {
 
     it('should return empty object if no state is available', done => {
       mockPrivacySignals(false, '1---', false);
-      connectid.getIds({pixelId: 12345, email: 'abc'}, response => {
+      connectId.getIds({pixelId: 12345, email: 'abc'}, response => {
         expect(response).toEqual({});
         done();
       });
@@ -133,11 +133,11 @@ describe('connectid', () => {
       mockPrivacySignals(false, '1---', false);
       spyOn(sync, 'syncIds');
       spyOn(sha256, 'getHashedIdentifier').and.callFake(mockGetHashedIdentifier);
-      connectid.getIds({pixelId: 12345, email: 'abc@foo.com'}, () => {
+      connectId.getIds({pixelId: 12345, email: 'abc@foo.com'}, () => {
         expect(sync.syncIds).toHaveBeenCalledWith({
           pixelId: 12345,
-          hashedEmail: MOCK_HASH_VALUE,
-          hashedPuid: undefined,
+          he: MOCK_HASH_VALUE,
+          puid: undefined,
           yahoo1p: undefined,
         });
         done();
@@ -148,11 +148,11 @@ describe('connectid', () => {
       mockPrivacySignals(false, '1---', false);
       spyOn(sync, 'syncIds');
       spyOn(sha256, 'getHashedIdentifier').and.callFake(mockGetHashedIdentifier);
-      connectid.getIds({pixelId: 12345, puid: 'abc'}, () => {
+      connectId.getIds({pixelId: 12345, puid: 'abc'}, () => {
         expect(sync.syncIds).toHaveBeenCalledWith({
           pixelId: 12345,
-          hashedEmail: undefined,
-          hashedPuid: MOCK_HASH_VALUE,
+          he: undefined,
+          puid: MOCK_HASH_VALUE,
           yahoo1p: undefined,
         });
         done();
@@ -164,7 +164,7 @@ describe('connectid', () => {
       Object.defineProperty(window, 'crypto', {value: null});
       mockPrivacySignals(false, '1---', false);
       spyOn(api, 'sendRequest');
-      connectid.getIds({pixelId: 12345, email: 'abc@foo.com'}, () => {
+      connectId.getIds({pixelId: 12345, email: 'abc@foo.com'}, () => {
         expect(api.sendRequest).not.toHaveBeenCalled();
         done();
       });
@@ -177,12 +177,12 @@ describe('connectid', () => {
       mockPrivacySignals(false, '1---', false);
       spyOn(sha256, 'getHashedIdentifier').and.callFake(mockGetHashedIdentifier);
       spyOn(sync, 'syncIds');
-      connectid.getIds({pixelId: 12345, email: 'abc'}, () => {
+      connectId.getIds({pixelId: 12345, email: 'abc'}, () => {
         expect(sync.syncIds).toHaveBeenCalledWith(
           {
             pixelId: 12345,
-            hashedEmail: MOCK_HASH_VALUE,
-            hashedPuid: undefined,
+            he: MOCK_HASH_VALUE,
+            puid: undefined,
             yahoo1p: undefined,
           },
         );

--- a/src/test/state.spec.js
+++ b/src/test/state.spec.js
@@ -7,7 +7,7 @@ const LOCALSTORAGE_KEY = 'yahoo-connectid';
 const MOCK_HASH_EMAIL = '7d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c91';
 const MOCK_HASH_PUID = '8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92';
 const MOCK_HASH_PUID_ALT = '9d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c93';
-const MOCK_CONNECTID = 'mock-connectid';
+const MOCK_CONNECTID = 'mock-connectId';
 
 describe('state', () => {
   const now = new Date();
@@ -29,63 +29,63 @@ describe('state', () => {
     });
 
     it('should return empty object if no state is stored for provided email', () => {
-      expect(state.getConnectId({hashedEmail: MOCK_HASH_EMAIL})).toEqual({});
+      expect(state.getConnectId({he: MOCK_HASH_EMAIL})).toEqual({});
     });
 
     it('should return stored state for specified email', () => {
       const mockState = {
-        hashedEmail: MOCK_HASH_EMAIL,
-        connectid: MOCK_CONNECTID,
+        he: MOCK_HASH_EMAIL,
+        connectId: MOCK_CONNECTID,
       };
 
       const expectedResult = {
-        connectid: MOCK_CONNECTID,
+        connectId: MOCK_CONNECTID,
       };
 
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(mockState));
-      expect(state.getConnectId({hashedEmail: MOCK_HASH_EMAIL})).toEqual(expectedResult);
+      expect(state.getConnectId({he: MOCK_HASH_EMAIL})).toEqual(expectedResult);
     });
 
     it('should return stored state for specified puid', () => {
       const mockState = {
-        hashedPuid: MOCK_HASH_PUID,
-        connectid: MOCK_CONNECTID,
+        puid: MOCK_HASH_PUID,
+        connectId: MOCK_CONNECTID,
       };
 
       const expectedResult = {
-        connectid: MOCK_CONNECTID,
+        connectId: MOCK_CONNECTID,
       };
 
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(mockState));
-      expect(state.getConnectId({hashedPuid: MOCK_HASH_PUID})).toEqual(expectedResult);
+      expect(state.getConnectId({puid: MOCK_HASH_PUID})).toEqual(expectedResult);
     });
 
     it('should return stored state if cached email exists but none passed in', () => {
       const mockState = {
-        hashedEmail: MOCK_HASH_EMAIL,
-        hashedPuid: MOCK_HASH_PUID,
-        connectid: MOCK_CONNECTID,
+        he: MOCK_HASH_EMAIL,
+        puid: MOCK_HASH_PUID,
+        connectId: MOCK_CONNECTID,
       };
 
       const expectedResult = {
-        connectid: MOCK_CONNECTID,
+        connectId: MOCK_CONNECTID,
       };
 
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(mockState));
-      expect(state.getConnectId({hashedPuid: MOCK_HASH_PUID_ALT})).toEqual(expectedResult);
+      expect(state.getConnectId({puid: MOCK_HASH_PUID_ALT})).toEqual(expectedResult);
     });
   });
 
   describe('setLocalData', () => {
     it('should store state for specified user', () => {
       const mockState = {
-        connectid: 'def_connectid',
-        hashedEmail: 'def',
+        connectId: 'def_connectId',
+        he: 'def',
       };
 
       const expectedStoredValue = {
-        hashedEmail: 'def',
-        connectid: 'def_connectid',
+        he: 'def',
+        connectId: 'def_connectId',
         expires: Date.now() + 24 * 60 * 60 * 1000,
       };
 
@@ -95,16 +95,16 @@ describe('state', () => {
 
     it('should not throw an exception if invalid state is provided', () => {
       expect(() => {
-        state.setLocalData({hashedEmail: 'abc', connectid: null});
+        state.setLocalData({he: 'abc', connectId: null});
       }).not.toThrow();
       expect(() => {
-        state.setLocalData({hashedEmail: 'abc', connectid: 123});
+        state.setLocalData({he: 'abc', connectId: 123});
       }).not.toThrow();
       expect(() => {
-        state.setLocalData({hashedEmail: 'abc', connectid: true});
+        state.setLocalData({he: 'abc', connectId: true});
       }).not.toThrow();
       expect(() => {
-        state.setLocalData({hashedEmail: 'abc', connectid: undefined});
+        state.setLocalData({he: 'abc', connectId: undefined});
       }).not.toThrow();
       expect(() => {
         state.setLocalData({});

--- a/src/test/state.spec.js
+++ b/src/test/state.spec.js
@@ -76,7 +76,7 @@ describe('state', () => {
     });
   });
 
-  describe('setConnectId', () => {
+  describe('setLocalData', () => {
     it('should store state for specified user', () => {
       const mockState = {
         connectid: 'def_connectid',
@@ -89,25 +89,25 @@ describe('state', () => {
         expires: Date.now() + 24 * 60 * 60 * 1000,
       };
 
-      state.setConnectId(mockState);
+      state.setLocalData(mockState);
       expect(localStorage.getItem(LOCALSTORAGE_KEY)).toEqual(JSON.stringify(expectedStoredValue));
     });
 
     it('should not throw an exception if invalid state is provided', () => {
       expect(() => {
-        state.setConnectId({hashedEmail: 'abc', connectid: null});
+        state.setLocalData({hashedEmail: 'abc', connectid: null});
       }).not.toThrow();
       expect(() => {
-        state.setConnectId({hashedEmail: 'abc', connectid: 123});
+        state.setLocalData({hashedEmail: 'abc', connectid: 123});
       }).not.toThrow();
       expect(() => {
-        state.setConnectId({hashedEmail: 'abc', connectid: true});
+        state.setLocalData({hashedEmail: 'abc', connectid: true});
       }).not.toThrow();
       expect(() => {
-        state.setConnectId({hashedEmail: 'abc', connectid: undefined});
+        state.setLocalData({hashedEmail: 'abc', connectid: undefined});
       }).not.toThrow();
       expect(() => {
-        state.setConnectId({});
+        state.setLocalData({});
       }).not.toThrow();
     });
   });

--- a/src/test/sync.spec.js
+++ b/src/test/sync.spec.js
@@ -4,13 +4,13 @@ import sinon from 'sinon';
 import api from '../api';
 import sync from '../sync';
 import state from '../state';
-import connectid from '../connectid';
+import connectId from '../connectid';
 import {MOCK_GDPR_TCSTRING, mockPrivacySignals} from './mockPrivacySignals';
 
 const LOCALSTORAGE_KEY = 'yahoo-connectid';
 const MOCK_HASH_EMAIL = '7d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c91';
 const MOCK_HASH_PUID = '8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92';
-const MOCK_CONNECTID = 'mock-connectid';
+const MOCK_CONNECTID = 'mock-connectId';
 
 describe('sync', () => {
   const now = new Date();
@@ -31,7 +31,7 @@ describe('sync', () => {
 
     it('should call api', () => {
       spyOn(api, 'sendRequest');
-      sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL});
+      sync.syncIds({pixelId: 12345, he: MOCK_HASH_EMAIL});
       expect(api.sendRequest).toHaveBeenCalledWith('https://ups.analytics.yahoo.com/ups/12345/fed', {
         he: MOCK_HASH_EMAIL,
         v: 1,
@@ -41,7 +41,7 @@ describe('sync', () => {
 
     it('should not call api if no identifiers available', done => {
       spyOn(api, 'sendRequest');
-      connectid.getIds({
+      connectId.getIds({
         pixelId: 12345,
         yahoo1p: true,
       }, () => {
@@ -52,8 +52,8 @@ describe('sync', () => {
 
     it('should not call api if no pixel id provided', done => {
       spyOn(api, 'sendRequest');
-      connectid.getIds({
-        hashedEmail: MOCK_HASH_EMAIL,
+      connectId.getIds({
+        he: MOCK_HASH_EMAIL,
         yahoo1p: true,
       }, () => {
         expect(api.sendRequest).not.toHaveBeenCalled();
@@ -63,13 +63,13 @@ describe('sync', () => {
 
     it('should not call api if local data is available and not stale', done => {
       localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify({
-        hashedEmail: MOCK_HASH_EMAIL,
-        connectid: 'abc_connectid',
+        he: MOCK_HASH_EMAIL,
+        connectId: 'abc_connectId',
         expires: Date.now() + 1000,
       }));
 
       spyOn(api, 'sendRequest');
-      connectid.getIds({pixelId: 123, email: MOCK_HASH_EMAIL}, () => {
+      connectId.getIds({pixelId: 123, email: MOCK_HASH_EMAIL}, () => {
         expect(api.sendRequest).not.toHaveBeenCalled();
         done();
       });
@@ -79,8 +79,8 @@ describe('sync', () => {
       spyOn(api, 'sendRequest');
       sync.syncIds({
         pixelId: 12345,
-        hashedEmail: MOCK_HASH_EMAIL,
-        hashedPuid: MOCK_HASH_PUID,
+        he: MOCK_HASH_EMAIL,
+        puid: MOCK_HASH_PUID,
         yahoo1p: true,
       });
       expect(api.sendRequest).toHaveBeenCalledWith('https://ups.analytics.yahoo.com/ups/12345/fed', {
@@ -97,7 +97,7 @@ describe('sync', () => {
       spyOn(api, 'sendRequest');
       sync.syncIds({
         pixelId: 12345,
-        hashedEmail: MOCK_HASH_EMAIL,
+        he: MOCK_HASH_EMAIL,
       });
       expect(api.sendRequest).toHaveBeenCalledWith('https://ups.analytics.yahoo.com/ups/12345/fed', {
         he: MOCK_HASH_EMAIL,
@@ -111,66 +111,66 @@ describe('sync', () => {
 
     // cache response
 
-    it('should cache connectid for hashedEmail', () => {
+    it('should cache connectId for he', () => {
       spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
-        callback({connectid: MOCK_CONNECTID, ttl: 24});
+        callback({connectId: MOCK_CONNECTID, ttl: 24});
       });
 
-      sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL});
+      sync.syncIds({pixelId: 12345, he: MOCK_HASH_EMAIL});
       expect(state.setLocalData).toHaveBeenCalledWith(
         {
-          connectid: MOCK_CONNECTID,
-          hashedEmail: MOCK_HASH_EMAIL,
+          connectId: MOCK_CONNECTID,
+          he: MOCK_HASH_EMAIL,
           ttl: 24,
         },
       );
     });
 
-    it('should cache connectid for hashedPuid', () => {
+    it('should cache connectId for puid', () => {
       spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
-        callback({connectid: MOCK_CONNECTID, ttl: 24});
+        callback({connectId: MOCK_CONNECTID, ttl: 24});
       });
 
-      sync.syncIds({pixelId: 12345, hashedPuid: MOCK_HASH_PUID});
+      sync.syncIds({pixelId: 12345, puid: MOCK_HASH_PUID});
       expect(state.setLocalData).toHaveBeenCalledWith(
         {
-          connectid: MOCK_CONNECTID,
-          hashedPuid: MOCK_HASH_PUID,
+          connectId: MOCK_CONNECTID,
+          puid: MOCK_HASH_PUID,
           ttl: 24,
         },
       );
     });
 
-    it('should cache connectid for hashedEmail and hashedPuid', () => {
+    it('should cache connectId for he and puid', () => {
       spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
-        callback({connectid: MOCK_CONNECTID, ttl: 24});
+        callback({connectId: MOCK_CONNECTID, ttl: 24});
       });
 
-      sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL, hashedPuid: MOCK_HASH_PUID});
+      sync.syncIds({pixelId: 12345, he: MOCK_HASH_EMAIL, puid: MOCK_HASH_PUID});
       expect(state.setLocalData).toHaveBeenCalledWith(
         {
-          connectid: MOCK_CONNECTID,
-          hashedEmail: MOCK_HASH_EMAIL,
-          hashedPuid: MOCK_HASH_PUID,
+          connectId: MOCK_CONNECTID,
+          he: MOCK_HASH_EMAIL,
+          puid: MOCK_HASH_PUID,
           ttl: 24,
         },
       );
     });
 
-    it('should update cache even when no connectid provided', () => {
+    it('should update cache even when no connectId provided', () => {
       spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
         callback({});
       });
 
-      sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL});
+      sync.syncIds({pixelId: 12345, he: MOCK_HASH_EMAIL});
       expect(state.setLocalData).toHaveBeenCalledWith(
         {
-          hashedEmail: MOCK_HASH_EMAIL,
-          connectid: undefined,
+          he: MOCK_HASH_EMAIL,
+          connectId: undefined,
           ttl: undefined,
         },
       );

--- a/src/test/sync.spec.js
+++ b/src/test/sync.spec.js
@@ -112,13 +112,13 @@ describe('sync', () => {
     // cache response
 
     it('should cache connectid for hashedEmail', () => {
-      spyOn(state, 'setConnectId');
+      spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
         callback({connectid: MOCK_CONNECTID, ttl: 24});
       });
 
       sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL});
-      expect(state.setConnectId).toHaveBeenCalledWith(
+      expect(state.setLocalData).toHaveBeenCalledWith(
         {
           connectid: MOCK_CONNECTID,
           hashedEmail: MOCK_HASH_EMAIL,
@@ -128,13 +128,13 @@ describe('sync', () => {
     });
 
     it('should cache connectid for hashedPuid', () => {
-      spyOn(state, 'setConnectId');
+      spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
         callback({connectid: MOCK_CONNECTID, ttl: 24});
       });
 
       sync.syncIds({pixelId: 12345, hashedPuid: MOCK_HASH_PUID});
-      expect(state.setConnectId).toHaveBeenCalledWith(
+      expect(state.setLocalData).toHaveBeenCalledWith(
         {
           connectid: MOCK_CONNECTID,
           hashedPuid: MOCK_HASH_PUID,
@@ -144,13 +144,13 @@ describe('sync', () => {
     });
 
     it('should cache connectid for hashedEmail and hashedPuid', () => {
-      spyOn(state, 'setConnectId');
+      spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
         callback({connectid: MOCK_CONNECTID, ttl: 24});
       });
 
       sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL, hashedPuid: MOCK_HASH_PUID});
-      expect(state.setConnectId).toHaveBeenCalledWith(
+      expect(state.setLocalData).toHaveBeenCalledWith(
         {
           connectid: MOCK_CONNECTID,
           hashedEmail: MOCK_HASH_EMAIL,
@@ -161,13 +161,13 @@ describe('sync', () => {
     });
 
     it('should update cache even when no connectid provided', () => {
-      spyOn(state, 'setConnectId');
+      spyOn(state, 'setLocalData');
       spyOn(api, 'sendRequest').and.callFake((apiUrl, data, callback) => {
         callback({});
       });
 
       sync.syncIds({pixelId: 12345, hashedEmail: MOCK_HASH_EMAIL});
-      expect(state.setConnectId).toHaveBeenCalledWith(
+      expect(state.setLocalData).toHaveBeenCalledWith(
         {
           hashedEmail: MOCK_HASH_EMAIL,
           connectid: undefined,


### PR DESCRIPTION
Prebid and the Pixel API use different terminology when referencing hashed emails, puids and the Connect ID.  This update is to align with their naming

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
